### PR TITLE
Delete app cache after patching.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,4 +90,7 @@ mv "$XPUI_SPA" "$XPUI_PATH"
 cd "$XPUI_PATH"
 rm -rf "$XPUI"
 
+# Delete app cache
+echo "Clearing app cache..."
+rm -rf "${HOME}/Library/Caches/com.spotify.client"
 echo -e "Patch applied successfully!\n"


### PR DESCRIPTION
Pre-existing Spotify app cache may make it appear as if a patch is not working. Deleting app cache seems to solve this without causing data loss related to signed-in account.