### PR TITLE
Avoid overwriting original xpui.bak

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,12 @@ echo
 
 # Create backup and extract xpui.js
 echo "Creating backup of xpui.spa..."
-cp "$XPUI_PATH/$XPUI_SPA" "$XPUI_PATH/$XPUI_SPA_BAK"
+if [[ -f "${XPUI_PATH}/${XPUI_SPA_BAK}" ]]; then
+    echo "Found xpui.bak, skipping backup..."
+else
+    echo "Creating backup of xpui.spa..."
+    cp "${XPUI_PATH}/${XPUI_SPA}" "${XPUI_PATH}/${XPUI_SPA_BAK}"
+fi
 
 echo "Extracting xpui.js..."
 cd "$XPUI_PATH"


### PR DESCRIPTION
Checks if xpui.bak already exists before trying to create xpui.bak -- this will avoid cases where script is run multiple times on the same Spotify install.