### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ AD_PLAYLIST_SPONSORS='s|allSponsorships||'
 AD_UPGRADE_BUTTON='s/(return|.=.=>)"free"===(.+?)(return|.=.=>)"premium"===/$1"premium"===$2$3"free"===/g'
 AD_AUDIO_ADS='s|(case .:)return this.enabled=...+?(;case .:this.subscription=this.audioApi).+?(;case .)|$1$2.cosmosConnector.increaseStreamTime(-100000000000)$3|'
 AD_BILLBOARD='s|.(\?\[..\(..leaderboard,)|false$1|'
-AD_UPSELL='s|(Enables quicksilver in-app messaging modal",default:)(!0)|$1false|s'
+AD_UPSELL='s|(Enables quicksilver in-app messaging modal",default:)(!0)|$1false|'
 
 # Log-related regex
 LOG_1='s|sp://logging/v3/\w+||g'


### PR DESCRIPTION
- add additional path and file vars
- add patches to remove logging and premium upsells
- edit regex to be more inline with SpotX-Win patches
- condense regex vars and reduce indent space used for if/else conditions

Other than the Sentry patch, all SpotX-Win patches work on macOS with almost no editing required. Switching the delimiter to avoid additional escaping may be needed in some cases (ex: s/// vs s|||). Keeping patches as close as possible in each repo should reduce debugging time and allow for faster updates as new builds are released. 

Since many regex patches will have their own unique search and replace strings, having 2 or more vars for each patch (1 search var; 1 replace var), condensing the vars to contain both the search and replace strings would reduce total lines of code as well as making future updating/editing easier since everything is on the same line. Some of the replace strings for true/false values in future experimental patches could technically be reused but the length of the variable would be the same as the replace string and not much is gained by reusing a variable. 