### PR TITLE
Update install.sh and readme.md

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,7 @@ AD_UPSELL='s|(Enables quicksilver in-app messaging modal",default:)(!0)|$1false|
 NEW_UI='s|(Enable the new home structure and navigation",values:.,default:)(..DISABLED)|$1true|'
 
 # Hide Premium-only features
-HIDE_DL_QUALITY='s/(.\("audio.play_bitrate_enumeration",.\)},)children:.*\(.,.\)}\).+\("audio.sync_bitrate_enumeration",.\)},(children:.*\(.,.\)}\)}\)]}\))/$1$2/'
+HIDE_DL_QUALITY='s/(children:..\(.,.\)|xe\(.,.\)\)\)\)).+?(children:..\(.,.\)|xe\(.,.\)\)\)\))/$1/'
 HIDE_DL_ICON=' .BKsbV2Xl786X9a09XROH {display:none}'
 HIDE_DL_MENU=' button.wC9sIed7pfp47wZbmU6m.pzkhLqffqF_4hucrVVQA {display:none}'
 HIDE_VERY_HIGH=' #desktop\.settings\.streamingQuality>option:nth-child(5) {display:none}'

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,7 @@ AD_UPSELL='s|(Enables quicksilver in-app messaging modal",default:)(!0)|$1false|
 NEW_UI='s|(Enable the new home structure and navigation",values:.,default:)(..DISABLED)|$1true|'
 
 # Hide Premium-only features
-HIDE_DL_QUALITY='s/(children:..\(.,.\)|xe\(.,.\)\)\)\)).+?(children:..\(.,.\)|xe\(.,.\)\)\)\))/$1/'
+HIDE_DL_QUALITY='s/(\(.,..jsxs\)\(.{1,3}|..createElement\(.{1,4}),{filterMatchQuery:.{1,6}get\("desktop.settings.downloadQuality.title.+?(children:.{1,2}\(.,.\).+?,|xe\(.,.\).+?,)//'
 HIDE_DL_ICON=' .BKsbV2Xl786X9a09XROH {display:none}'
 HIDE_DL_MENU=' button.wC9sIed7pfp47wZbmU6m.pzkhLqffqF_4hucrVVQA {display:none}'
 HIDE_VERY_HIGH=' #desktop\.settings\.streamingQuality>option:nth-child(5) {display:none}'

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ AD_EMPTY_AD_BLOCK='s|adsEnabled:!0|adsEnabled:!1|'
 AD_PLAYLIST_SPONSORS='s|allSponsorships||'
 AD_UPGRADE_BUTTON='s/(return|.=.=>)"free"===(.+?)(return|.=.=>)"premium"===/$1"premium"===$2$3"free"===/g'
 AD_AUDIO_ADS='s|(case .:)return this.enabled=...+?(;case .:this.subscription=this.audioApi).+?(;case .)|$1$2.cosmosConnector.increaseStreamTime(-100000000000)$3|'
-AD_BILLBOARD='s|.(\?\[..\(..leaderboard,)|false$1|'
+AD_BILLBOARD='s|.(\?\[....\.leaderboard,)|false$1|'
 AD_UPSELL='s|(Enables quicksilver in-app messaging modal",default:)(!0)|$1false|'
 
 # Home screen UI (new) | this will soon become obsolete

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # Inital paths and filenames
-
 APP_PATH="/Applications/Spotify.app"
 if [[ -d "${HOME}${APP_PATH}" ]]; then
   INSTALL_PATH="${HOME}${APP_PATH}"
@@ -9,29 +8,41 @@ elif [[ -d "${APP_PATH}" ]]; then
   INSTALL_PATH="${APP_PATH}"
 else
   echo -e "\nSpotify not found. Exiting...\n"
-  exit
-fi
+  exit; fi
 
 CACHE_PATH="${HOME}/Library/Caches/com.spotify.client"
+UPDATE_PATH="${HOME}/Library/Application Support/Spotify/PersistentCache/Update"
 XPUI_PATH="${INSTALL_PATH}/Contents/Resources/Apps"
 XPUI_DIR="${XPUI_PATH}/xpui"
 XPUI_BAK="${XPUI_PATH}/xpui.bak"
 XPUI_SPA="${XPUI_PATH}/xpui.spa"
 XPUI_JS="${XPUI_DIR}/xpui.js"
+XPUI_CSS="${XPUI_DIR}/xpui.css"
+HOME_V2_JS="${XPUI_DIR}/home-v2.js"
 VENDOR_XPUI_JS="${XPUI_DIR}/vendor~xpui.js"
 
 # Script flags
 CACHE_FLAG='false'
+HIDE_PODCASTS_FLAG='false'
+OLD_UI_FLAG='false'
+PREMIUM_FLAG='false'
+UPDATE_FLAG='false'
 
-while getopts 'c' flag; do
+while getopts 'chopu' flag; do
   case "${flag}" in
     c) 
-      CACHE_FLAG='true'
-      ;;
+      CACHE_FLAG='true' ;;
+    h)
+      HIDE_PODCASTS_FLAG='true' ;;
+    o)
+      OLD_UI_FLAG='true' ;;
+    p)
+      PREMIUM_FLAG='true' ;;
+    u)
+      UPDATE_FLAG='true' ;;
     *) 
       echo "Error: Flag not supported."
-      exit
-      ;;
+      exit ;;
   esac
 done
 
@@ -46,68 +57,131 @@ AD_AUDIO_ADS='s|(case .:)return this.enabled=...+?(;case .:this.subscription=thi
 AD_BILLBOARD='s|.(\?\[..\(..leaderboard,)|false$1|'
 AD_UPSELL='s|(Enables quicksilver in-app messaging modal",default:)(!0)|$1false|'
 
+# Home screen UI (new) | this will soon become obsolete
+NEW_UI='s|(Enable the new home structure and navigation",values:.,default:)(..DISABLED)|$1true|'
+
+# Hide Premium-only features
+HIDE_DL_QUALITY='s/(children:..\(.,.\)|xe\(.,.\)\)\)\)).+?(children:..\(.,.\)|xe\(.,.\)\)\)\))/$1/'
+HIDE_DL_ICON=' .BKsbV2Xl786X9a09XROH {display:none}'
+HIDE_DL_MENU=' button.wC9sIed7pfp47wZbmU6m.pzkhLqffqF_4hucrVVQA {display:none}'
+HIDE_VERY_HIGH=' #desktop\.settings\.streamingQuality>option:nth-child(5) {display:none}'
+
+# Hide Podcasts/Episodes/Audiobooks on home screen
+HIDE_PODCASTS='s/(\!Array.isArray\(.\)\|\|.===..length)/$1||e.children[0].key.includes('episode')||e.children[0].key.includes('show')/'
+
 # Log-related regex
 LOG_1='s|sp://logging/v3/\w+||g'
 LOG_SENTRY='s|this\.getStackTop\(\)\.client=e|return;$&|'
 
+# Spotify Connect unlock
+CONNECT_1='s| connect-device-list-item--disabled||'
+CONNECT_2='s|connect-picker.unavailable-to-control|spotify-connect|'
+CONNECT_3='s|(className:.,disabled:)(..)|$1false|'
+CONNECT_4='s/return (..isDisabled)(\?(..createElement|\(.{1,10}\))\(..,)/return false$2/'
+
 # Credits
+echo
 echo "************************"
 echo "SpotX-Mac by @SpotX-CLI"
 echo "************************"
 echo
 
 # Create backup and extract xpui.js
-echo "Creating backup of xpui.spa..."
-if [[ -f "${XPUI_PATH}/${XPUI_SPA_BAK}" ]]; then
+if [[ -f "${XPUI_BAK}" ]]; then
   echo "Found xpui.bak, skipping backup..."
 else
   echo "Creating backup of xpui.spa..."
-  cp "${XPUI_SPA}" "${XPUI_BAK}"
-fi
+  cp "${XPUI_SPA}" "${XPUI_BAK}"; fi
 
 echo "Extracting xpui.js..."
 unzip -qq "${XPUI_SPA}" -d "${XPUI_DIR}"
 rm "${XPUI_SPA}"
 
-# Remove Ads
 echo "Applying SpotX patches..."
 
-# Remove Empty ad block
-echo "Removing empty ad block..."
-$PERL "${AD_EMPTY_AD_BLOCK}" "${XPUI_JS}"
-
-# Remove Playlist sponsors
-echo "Removing playlist sponsors..."
-$PERL "${AD_PLAYLIST_SPONSORS}" "${XPUI_JS}"
-
-# Remove Upgrade button
-echo "Removing upgrade button..."
-$PERL "${AD_UPGRADE_BUTTON}" "${XPUI_JS}"
-
-# Remove Audio ads
-echo "Removing audio ads..."
-$PERL "${AD_AUDIO_ADS}" "${XPUI_JS}"
-
-# Remove billboard ads
-echo "Removing billboard ads..."
-$PERL "${AD_BILLBOARD}" "${XPUI_JS}"
+if [[ "${PREMIUM_FLAG}" == "false" ]]; then
+  # Remove Empty ad block
+  echo "Removing empty ad block..."
+  $PERL "${AD_EMPTY_AD_BLOCK}" "${XPUI_JS}"
+  
+  # Remove Playlist sponsors
+  echo "Removing playlist sponsors..."
+  $PERL "${AD_PLAYLIST_SPONSORS}" "${XPUI_JS}"
+  
+  # Remove Upgrade button
+  echo "Removing upgrade button..."
+  $PERL "${AD_UPGRADE_BUTTON}" "${XPUI_JS}"
+  
+  # Remove Audio ads
+  echo "Removing audio ads..."
+  $PERL "${AD_AUDIO_ADS}" "${XPUI_JS}"
+  
+  # Remove billboard ads
+  echo "Removing billboard ads..."
+  $PERL "${AD_BILLBOARD}" "${XPUI_JS}"
+  
+  # Remove premium upsells
+  echo "Removing premium upselling..."
+  $PERL "${AD_UPSELL}" "${XPUI_JS}"
+  
+  # Remove Premium-only features
+  echo "Removing premium-only features..."
+  $PERL "${HIDE_DL_QUALITY}" "${XPUI_JS}"
+  echo >> "${HIDE_DL_ICON}" "${XPUI_CSS}"
+  echo >> "${HIDE_DL_MENU}" "${XPUI_CSS}"
+  echo >> "${HIDE_VERY_HIGH}" "${XPUI_CSS}"
+  
+  # Unlock Spotify Connect
+  echo "Unlocking Spotify Connect..."
+  $PERL "${CONNECT_1}" "${XPUI_JS}"
+  $PERL "${CONNECT_2}" "${XPUI_JS}"
+  $PERL "${CONNECT_3}" "${XPUI_JS}"
+  $PERL "${CONNECT_4}" "${XPUI_JS}"
+else
+  echo "Premium subscription setup selected..."; fi
 
 # Remove logging
 echo "Removing logging..."
 $PERL "${LOG_1}" "${XPUI_JS}"
 $PERL "${LOG_SENTRY}" "${VENDOR_XPUI_JS}"
 
-# Rebuild xpui.spa
-echo "Rebuilding xpui.spa..."
+# Handle UI view | this will soon become obsolete
+if [[ "${OLD_UI_FLAG}" == "true" ]]; then
+  echo "Skipping new home UI patch..."
+else
+  echo "Forcing new home UI..."
+  $PERL "${NEW_UI}" "${XPUI_JS}"; fi
 
-# Zip files inside xpui folder
-(cd "${XPUI_DIR}"; zip -qq -r ../xpui.spa .)
-rm -rf "${XPUI_DIR}"
+# Hide podcasts, episodes and audiobooks on home screen
+if [[ "${HIDE_PODCASTS_FLAG}" == "true" ]]; then
+  echo "Hiding non-music items on home screen..."
+  $PERL "${HIDE_PODCASTS}" "${HOME_V2_JS}"; fi
 
 # Delete app cache
 if [[ "${CACHE_FLAG}" == "true" ]]; then
   echo "Clearing app cache..."
-  rm -rf "$CACHE_PATH"
-fi
+  rm -rf "$CACHE_PATH"; fi
+  
+# Update handling
+if [[ "${UPDATE_FLAG}" == "true" ]]; then
+  echo "Blocking updates..."
+  if [[ -d "${UPDATE_PATH}" ]]; then
+    chflags nouchg "${UPDATE_PATH}" 2>/dev/null
+    rm -rf "${UPDATE_PATH}" 
+    mkdir -p "${UPDATE_PATH}"
+    chflags uchg "${UPDATE_PATH}"
+  else
+    mkdir -p "${UPDATE_PATH}"
+    chflags uchg "${UPDATE_PATH}"; fi
+else
+  if [[ -d "${UPDATE_PATH}" ]]; then
+    chflags nouchg "${UPDATE_PATH}" 2>/dev/null; fi; fi
+  
+# Rebuild xpui.spa
+echo "Rebuilding xpui.spa..."
+  
+# Zip files inside xpui folder
+(cd "${XPUI_DIR}"; zip -qq -r ../xpui.spa .)
+rm -rf "${XPUI_DIR}"
 
-echo -e "Patch applied successfully!\n"
+echo -e "SpotX patches applied successfully!\n"

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,7 @@ AD_UPSELL='s|(Enables quicksilver in-app messaging modal",default:)(!0)|$1false|
 NEW_UI='s|(Enable the new home structure and navigation",values:.,default:)(..DISABLED)|$1true|'
 
 # Hide Premium-only features
-HIDE_DL_QUALITY='s/(children:..\(.,.\)|xe\(.,.\)\)\)\)).+?(children:..\(.,.\)|xe\(.,.\)\)\)\))/$1/'
+HIDE_DL_QUALITY='s/children:.+\(.,.\).+(children:.+}\)}\)]}\))/$1/'
 HIDE_DL_ICON=' .BKsbV2Xl786X9a09XROH {display:none}'
 HIDE_DL_MENU=' button.wC9sIed7pfp47wZbmU6m.pzkhLqffqF_4hucrVVQA {display:none}'
 HIDE_VERY_HIGH=' #desktop\.settings\.streamingQuality>option:nth-child(5) {display:none}'

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,7 @@ AD_UPSELL='s|(Enables quicksilver in-app messaging modal",default:)(!0)|$1false|
 NEW_UI='s|(Enable the new home structure and navigation",values:.,default:)(..DISABLED)|$1true|'
 
 # Hide Premium-only features
-HIDE_DL_QUALITY='s/children:.+\(.,.\).+(children:.+}\)}\)]}\))/$1/'
+HIDE_DL_QUALITY='s/(.\("audio.play_bitrate_enumeration",.\)},)children:.*\(.,.\)}\).+\("audio.sync_bitrate_enumeration",.\)},(children:.*\(.,.\)}\)}\)]}\))/$1$2/'
 HIDE_DL_ICON=' .BKsbV2Xl786X9a09XROH {display:none}'
 HIDE_DL_MENU=' button.wC9sIed7pfp47wZbmU6m.pzkhLqffqF_4hucrVVQA {display:none}'
 HIDE_VERY_HIGH=' #desktop\.settings\.streamingQuality>option:nth-child(5) {display:none}'

--- a/install.sh
+++ b/install.sh
@@ -127,9 +127,9 @@ if [[ "${PREMIUM_FLAG}" == "false" ]]; then
   # Remove Premium-only features
   echo "Removing premium-only features..."
   $PERL "${HIDE_DL_QUALITY}" "${XPUI_JS}"
-  echo >> "${HIDE_DL_ICON}" "${XPUI_CSS}"
-  echo >> "${HIDE_DL_MENU}" "${XPUI_CSS}"
-  echo >> "${HIDE_VERY_HIGH}" "${XPUI_CSS}"
+  echo "${HIDE_DL_ICON}" >> "${XPUI_CSS}"
+  echo "${HIDE_DL_MENU}" >> "${XPUI_CSS}"
+  echo "${HIDE_VERY_HIGH}" >> "${XPUI_CSS}"
   
   # Unlock Spotify Connect
   echo "Unlocking Spotify Connect..."

--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ done
 PERL="perl -pi -w -e"
 
 # Ad-related regex
-AD_EMPTY_AD_BLOCK='s|adsEnabled:\!\K0|1|'
+AD_EMPTY_AD_BLOCK='s|adsEnabled:!0|adsEnabled:!1|'
 AD_PLAYLIST_SPONSORS='s|allSponsorships||'
 AD_UPGRADE_BUTTON='s/(return|.=.=>)"free"===(.+?)(return|.=.=>)"premium"===/$1"premium"===$2$3"free"===/g'
 AD_AUDIO_ADS='s|(case .:)return this.enabled=...+?(;case .:this.subscription=this.audioApi).+?(;case .)|$1$2.cosmosConnector.increaseStreamTime(-100000000000)$3|'

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,12 @@
 [![Discord](https://discord.com/api/guilds/807273906872123412/widget.png)](https://discord.gg/p43cusgUPm)
 
 <center>
-    <h1 align="center">SpotX for MacOS</h1>
-    <h4 align="center">A multi-purpose adblocker and skip-bypass for the Spotify MacOS application.</h4>
+    <h1 align="center">SpotX for macOS</h1>
+    <h4 align="center">A multi-purpose adblocker and skip-bypass for the Spotify macOS application.</h4>
     <h5 align="center">Please support Spotify by purchasing premium</h5>
     <p align="center">
         <strong>Last updated:</strong> 11 October 2022<br>
-        <strong>Last tested version:</strong> Spotify for macOS 1.1.96.783.ga553e8b1
+        <strong>Last tested version:</strong> 1.1.96.783.ga553e8b1
     </p> 
 </center>
 

--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,8 @@
     <h4 align="center">A multi-purpose adblocker and skip-bypass for the Spotify MacOS application.</h4>
     <h5 align="center">Please support Spotify by purchasing premium</h5>
     <p align="center">
-        <strong>Last updated:</strong> 10 October 2022<br>
-        <strong>Last tested version:</strong> Spotify for macOS 1.1.95.893.g6cf4d40c
+        <strong>Last updated:</strong> 11 October 2022<br>
+        <strong>Last tested version:</strong> Spotify for macOS 1.1.96.783.ga553e8b1
     </p> 
 </center>
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
     <h4 align="center">A multi-purpose adblocker and skip-bypass for the Spotify MacOS application.</h4>
     <h5 align="center">Please support Spotify by purchasing premium</h5>
     <p align="center">
-        <strong>Last updated:</strong> 1 October 2022<br>
+        <strong>Last updated:</strong> 10 October 2022<br>
         <strong>Last tested version:</strong> Spotify for macOS 1.1.95.893.g6cf4d40c
     </p> 
 </center>
@@ -15,6 +15,8 @@
 - Blocks all banner/video/audio ads within the app
 - Retains friend, vertical video and radio functionality
 - Unlocks the skip function for any track
+- Blocks Spotify automatic updates (optional)
+- Hides podcasts, episodes and audiobooks (optional)
 
 ### Installation/Update:
 
@@ -26,10 +28,16 @@ curl -sL https://raw.githubusercontent.com/SpotX-CLI/SpotX-Mac/main/install.sh |
 ```
 
 #### Optional Install Arguments:
-`-c` Clear app cache in case patch doesn't work correctly.
-    
+`-c` Clear app cache -- use if patch doesn't work correctly  
+`-h` Hide podcasts, episodes and audiobooks on home screen  
+`-o` Old UI -- skips forced 'new UI' patch  
+`-p` Premium subscription setup -- use if premium subscriber  
+`-u` Update block -- use to block automatic updates  
+
+Use any combination of flags.  
+The following example clears app cache, skips new UI patch and blocks updates:
 ```
-curl -sL https://raw.githubusercontent.com/SpotX-CLI/SpotX-Mac/main/install.sh | bash -s -- -c
+curl -sL https://raw.githubusercontent.com/SpotX-CLI/SpotX-Mac/main/install.sh | bash -s -- -cou
 ```
 
 


### PR DESCRIPTION
- add additional file/path vars
- add patches to hide "Premium-only" features 
- add patch to force 'new UI'
- add patches to unlock "Premium-only" Spotify Connect devices
- add flag to block automatic updates
- add flag to hide podcasts/episodes/audiobooks from home screen
- add flag to skip 'new UI' patch
- add premium flag (skips all ad-related and premium-enabling feature patches if set)
- update README with new flags