### PR TITLE
Update regex

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,7 @@ AD_UPSELL='s|(Enables quicksilver in-app messaging modal",default:)(!0)|$1false|
 NEW_UI='s|(Enable the new home structure and navigation",values:.,default:)(..DISABLED)|$1true|'
 
 # Hide Premium-only features
-HIDE_DL_QUALITY='s/(\(.,..jsxs\)\(.{1,3}|..createElement\(.{1,4}),{filterMatchQuery:.{1,6}get\("desktop.settings.downloadQuality.title.+?(children:.{1,2}\(.,.\).+?,|xe\(.,.\).+?,)//'
+HIDE_DL_QUALITY='s/(\(.,..jsxs\)\(.{1,3}|..createElement\(.{1,4}),\{filterMatchQuery:.{1,6}get\("desktop.settings.downloadQuality.title.+?(children:.{1,2}\(.,.\).+?,|xe\(.,.\).+?,)//'
 HIDE_DL_ICON=' .BKsbV2Xl786X9a09XROH {display:none}'
 HIDE_DL_MENU=' button.wC9sIed7pfp47wZbmU6m.pzkhLqffqF_4hucrVVQA {display:none}'
 HIDE_VERY_HIGH=' #desktop\.settings\.streamingQuality>option:nth-child(5) {display:none}'


### PR DESCRIPTION
As of Perl 5.26, literal left braces must be escaped. macOS 11.x started shipping with Perl 5.30.x.