### PR TITLE
1.1.97 bringup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,7 @@ PERL="perl -pi -w -e"
 AD_EMPTY_AD_BLOCK='s|adsEnabled:!0|adsEnabled:!1|'
 AD_PLAYLIST_SPONSORS='s|allSponsorships||'
 AD_UPGRADE_BUTTON='s/(return|.=.=>)"free"===(.+?)(return|.=.=>)"premium"===/$1"premium"===$2$3"free"===/g'
-AD_AUDIO_ADS='s/(case .:|async enable\(.\)\{)(this.enabled=.+?\(.{1,3},"audio"\),\|return this.enabled=...+?\(.{1,3},"audio"\))((;case 4:)?this.subscription=this.audioApi).+?this.onAdMessage\)/$1$3.cosmosConnector.increaseStreamTime(-100000000000)/'
+AD_AUDIO_ADS='s/(case .:|async enable\(.\)\{)(this.enabled=.+?\(.{1,3},"audio"\),|return this.enabled=...+?\(.{1,3},"audio"\))((;case 4:)?this.subscription=this.audioApi).+?this.onAdMessage\)/$1$3.cosmosConnector.increaseStreamTime(-100000000000)/'
 AD_BILLBOARD='s|.(\?\[....\.leaderboard,)|false$1|'
 AD_UPSELL='s|(Enables quicksilver in-app messaging modal",default:)(!0)|$1false|'
 

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ ENABLE_SEARCH_BOX='s|(Adds a search box so users are able to filter playlists wh
 ENABLE_SIMILAR_PLAYLIST='s/,(.\.isOwnedBySelf&&)((\(.{0,11}\)|..createElement)\(.{1,3}Fragment,.+?{(uri:.|spec:.),(uri:.|spec:.).+?contextmenu.create-similar-playlist"\)}\),)/,$2$1/s'
 
 # Home screen UI (new) | this will soon become obsolete
-NEW_UI='s|(Enable the new home structure and navigation\",values:.,default:.)(.DISABLED)|$1.ENABLED_CENTER|'
+NEW_UI='s|(Enable the new home structure and navigation",values:.,default:.)(.DISABLED)|$1.ENABLED_CENTER|'
 
 # Hide Premium-only features
 HIDE_DL_QUALITY='s/(\(.,..jsxs\)\(.{1,3}|..createElement\(.{1,4}),\{filterMatchQuery:.{1,6}get\("desktop.settings.downloadQuality.title.+?(children:.{1,2}\(.,.\).+?,|xe\(.,.\).+?,)//'

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ or
 
 ### DISCLAIMER
 
-- Ad blocking is the main concern of this repo. Any other feature provided by SpotX-Linux or consequence of using those features will be the sole responsibility of the user, not BlockTheSpot/SpotX/SpotX-CLI/SpotX-Mac.
+- Ad blocking is the main concern of this repo. Any other feature provided by SpotX-Mac or consequence of using those features will be the sole responsibility of the user, not BlockTheSpot/SpotX/SpotX-CLI/SpotX-Mac.
 
 ### Credits
 

--- a/readme.md
+++ b/readme.md
@@ -10,17 +10,17 @@
  ***     
 
 <center>
-    <h4 align="center">A multi-purpose adblocker and skip-bypass for the Spotify macOS application.</h4>
+    <h4 align="center">A multi-featured adblocker and skip-bypass for the Spotify macOS application.</h4>
     <p align="center">
-        <strong>Last updated:</strong> 18 October 2022<br>
-        <strong>Last tested version:</strong> 1.1.96.785.g464c973a
+        <strong>Last updated:</strong> 27 October 2022<br>
+        <strong>Last tested version:</strong> 1.1.97.962
     </p> 
 </center>
 
 ### Features:
 
 - Blocks all banner/video/audio ads within the app
-- Retains friend, vertical video and radio functionality
+- Blocks logging (Sentry, etc)
 - Unlocks the skip function for any track
 - Blocks Spotify automatic updates (optional)
 - Enables [experimental features](https://github.com/SpotX-CLI/SpotX-Win/discussions/50) (optional)
@@ -67,7 +67,7 @@ or
 
 ### DISCLAIMER
 
-- Ad blocking is the main concern of this repo. Any other feature provided by SpotX-Mac or consequence of using those features will be the sole responsibility of the user and not either BlockTheSpot or SpotX, SpotX-Mac team will be responsible.
+- Ad blocking is the main concern of this repo. Any other feature provided by SpotX-Linux or consequence of using those features will be the sole responsibility of the user, not BlockTheSpot/SpotX/SpotX-CLI/SpotX-Mac.
 
 ### Credits
 


### PR DESCRIPTION
- update audio ads regex, supports v1.1.58+
- update new UI regex
- add regex for hiding podcasts in 1.1.97
- fix regex for hiding podcasts in v1.1.93 - v1.1.96
- add client version handling
- fix typos and condense lines