### PR TITLE
add flag for custom app path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,15 +7,58 @@ command -v perl >/dev/null || { echo -e "\nperl was not found, exiting...\n" >&2
 command -v unzip >/dev/null || { echo -e "\nunzip was not found, exiting...\n" >&2; exit 1; }
 command -v zip >/dev/null || { echo -e "\nzip was not found, exiting...\n" >&2; exit 1; }
 
-# Inital paths and filenames
+# Script flags
 APP_PATH="/Applications/Spotify.app"
-if [[ -d "${HOME}${APP_PATH}" ]]; then
-  INSTALL_PATH="${HOME}${APP_PATH}"
-elif [[ -d "${APP_PATH}" ]]; then
-  INSTALL_PATH="${APP_PATH}"
+CACHE_FLAG='false'
+EXCLUDE_FLAG=''
+EXPERIMENTAL_FLAG='false'
+FORCE_FLAG='false'
+HIDE_PODCASTS_FLAG='false'
+OLD_UI_FLAG='false'
+PATH_FLAG='false'
+PREMIUM_FLAG='false'
+UPDATE_FLAG='false'
+CUSTOM_APP_PATH='false'
+
+while getopts 'cE:efhopuP:' flag; do
+  case "${flag}" in
+  c) CACHE_FLAG='true' ;;
+  E) EXCLUDE_FLAG+=("${OPTARG}") ;;
+  e) EXPERIMENTAL_FLAG='true' ;;
+  f) FORCE_FLAG='true' ;;
+  h) HIDE_PODCASTS_FLAG='true' ;;
+  o) OLD_UI_FLAG='true' ;;
+  p) PREMIUM_FLAG='true' ;;
+  P)
+    APP_PATH="${OPTARG}"
+    PATH_FLAG='true'
+    ;;
+  u) UPDATE_FLAG='true' ;;
+  *)
+    echo "Error: Flag not supported."
+    exit
+    ;;
+  esac
+done
+
+# Inital paths and filenames
+if [[ "${PATH_FLAG}" == 'false' ]]; then
+  if [[ -d "${HOME}${APP_PATH}" ]]; then
+    INSTALL_PATH="${HOME}${APP_PATH}"
+  elif [[ -d "${APP_PATH}" ]]; then
+    INSTALL_PATH="${APP_PATH}"
+  else
+    echo -e "\nSpotify not found. Exiting...\n"
+    exit
+  fi
 else
-  echo -e "\nSpotify not found. Exiting...\n"
-  exit; fi
+  if [[ -d "${APP_PATH}" ]]; then
+    INSTALL_PATH="${APP_PATH}"
+  else
+    echo -e "\nSpotify not found. Exiting...\n"
+    exit
+  fi
+fi
 
 CACHE_PATH="${HOME}/Library/Caches/com.spotify.client"
 UPDATE_PATH="${HOME}/Library/Application Support/Spotify/PersistentCache/Update"
@@ -33,32 +76,6 @@ CLIENT_VERSION=$(awk '/CFBundleShortVersionString/{getline; print}' "${INSTALL_P
 
 # Version function for version comparison
 function ver { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
-
-# Script flags
-CACHE_FLAG='false'
-EXCLUDE_FLAG=''
-EXPERIMENTAL_FLAG='false'
-FORCE_FLAG='false'
-HIDE_PODCASTS_FLAG='false'
-OLD_UI_FLAG='false'
-PREMIUM_FLAG='false'
-UPDATE_FLAG='false'
-
-while getopts 'cE:efhopu' flag; do
-  case "${flag}" in
-    c) CACHE_FLAG='true' ;;
-    E) EXCLUDE_FLAG+=("${OPTARG}") ;;
-    e) EXPERIMENTAL_FLAG='true' ;;
-    f) FORCE_FLAG='true' ;;
-    h) HIDE_PODCASTS_FLAG='true' ;;
-    o) OLD_UI_FLAG='true' ;;
-    p) PREMIUM_FLAG='true' ;;
-    u) UPDATE_FLAG='true' ;;
-    *) 
-      echo "Error: Flag not supported."
-      exit ;;
-  esac
-done
 
 # Handle multiple "exclude" flags if desired
 for EXCLUDE_VAL in "${EXCLUDE_FLAG[@]}"; do

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,8 @@ bash <(curl -sSL https://raw.githubusercontent.com/SpotX-CLI/SpotX-Mac/main/inst
 `-f`  Force patch -- forces re-patching if backup detected  
 `-h`  Hide podcasts, episodes and audiobooks on home screen  
 `-o`  Old UI -- skips forced 'new UI' patch  
-`-p`  Premium subscription setup -- use if premium subscriber  
+`-p`  Premium subscription setup -- use if premium subscriber
+`-P`  Path to Spotify.app -- set custom Spotify app path
 `-u`  Update block -- blocks automatic updates  
 
 Use any combination of flags.  

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,14 +1,38 @@
 #!/usr/bin/env bash
 
-# Inital paths and filenames
 APP_PATH="/Applications/Spotify.app"
-if [[ -d "${HOME}${APP_PATH}" ]]; then
-  INSTALL_PATH="${HOME}${APP_PATH}"
-elif [[ -d "${APP_PATH}" ]]; then
-  INSTALL_PATH="${APP_PATH}"
+PATH_FLAG='false'
+
+while getopts 'P:' flag; do
+  case "${flag}" in
+  P)
+    APP_PATH="${OPTARG}"
+    PATH_FLAG='true'
+    ;;
+  *)
+    echo "Error: Flag not supported."
+    exit
+    ;;
+  esac
+done
+
+# Inital paths and filenames
+if [[ "${PATH_FLAG}" == 'false' ]]; then
+  if [[ -d "${HOME}${APP_PATH}" ]]; then
+    INSTALL_PATH="${HOME}${APP_PATH}"
+  elif [[ -d "${APP_PATH}" ]]; then
+    INSTALL_PATH="${APP_PATH}"
+  else
+    echo -e "\nSpotify not found. Exiting...\n"
+    exit
+  fi
 else
-  echo -e "\nSpotify not found. Exiting...\n"
-  exit
+  if [[ -d "${APP_PATH}" ]]; then
+    INSTALL_PATH="${APP_PATH}"
+  else
+    echo -e "\nSpotify not found. Exiting...\n"
+    exit
+  fi
 fi
 XPUI_PATH="${INSTALL_PATH}/Contents/Resources/Apps"
 XPUI_SPA="${XPUI_PATH}/xpui.spa"


### PR DESCRIPTION
I wanted to use this while having nix home-manager manager my Spotify install, this means that Spotify is not installed in the usual location.

This PR simply adds a flag `-a` that allows a user to specify the path of the Spotify app.